### PR TITLE
Exclude date based inputs from focus cloning

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -187,7 +187,7 @@ ionic.tap = {
 
     ionic.requestAnimationFrame(function() {
       var focusInput = container.querySelector(':focus');
-      if (ionic.tap.isTextInput(focusInput)) {
+      if (ionic.tap.isTextInput(focusInput) && !ionic.tap.isDateInput(focusInput)) {
         var clonedInput = focusInput.cloneNode(true);
         
         clonedInput.value = focusInput.value;


### PR DESCRIPTION
Date based inputs are not treated properly, their values are blanked when scrolling occurs.
